### PR TITLE
Fix failing import from markupsafe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ LABEL "homepage"="https://github.com/grantmcconnaughey/lintly-flake8-github-acti
 LABEL "maintainer"="Grant McConnaughey <grantmcconnaughey@gmail.com>"
 
 RUN pip install --upgrade pip
+RUN pip install markupsafe==2.0.1
 RUN pip install flake8
 RUN pip install lintly
 


### PR DESCRIPTION
This PR fixes a compatibility issue with an import from "markupsafe"

Credit to https://github.com/ikerexxe with the original PR at https://github.com/grantmcconnaughey/lintly-flake8-github-action/pull/16